### PR TITLE
feat: batches implemented in web3 multicall adapter

### DIFF
--- a/packages/core-sdk/lib/Adapters/Multicall/Web3MulticallAdapter.ts
+++ b/packages/core-sdk/lib/Adapters/Multicall/Web3MulticallAdapter.ts
@@ -17,13 +17,16 @@ type GroupedUseCases = {
   useCases: Array<{ order: number; useCase: GenericUseCase }>;
 };
 
-type MultiCallParams = { mode?: 'chunks' | 'single', chunkSize?: number }
+type MultiCallParams = { mode?: "chunks" | "single"; chunkSize?: number };
 
 type OrderedContractUseCaseMap = Record<string, GroupedUseCases>;
 
 export class Web3MulticallAdapter extends MulticallBaseAdapter {
   protected multicall?: Multicall;
-  constructor(adapter: IAdapter, private multiCallParams: MultiCallParams = {mode: 'chunks', chunkSize: 50}) {
+  constructor(
+    adapter: IAdapter,
+    private multiCallParams: MultiCallParams = { mode: "chunks", chunkSize: 50 }
+  ) {
     super(adapter);
 
     if (this.isMulticallSupported) {
@@ -47,11 +50,11 @@ export class Web3MulticallAdapter extends MulticallBaseAdapter {
     ).map(this.mapGroupedUseCasesToMulticallCtx.bind(this));
 
     const chunks = this.getChunks([...callContexts]);
-    let result : ExecutionResponse<any>[] = []
+    let result: ExecutionResponse<any>[] = [];
     for (let chunk of chunks) {
       let chunkResult = await this.multicall
-      .call(chunk)
-      .then<ExecutionResponse<any>[]>(this.processMulticallResult.bind(this));
+        .call(chunk)
+        .then<ExecutionResponse<any>[]>(this.processMulticallResult.bind(this));
       this._mergeArray(result, chunkResult);
     }
     return result;
@@ -103,7 +106,7 @@ export class Web3MulticallAdapter extends MulticallBaseAdapter {
     res: ContractCallResults
   ): ExecutionResponse[] {
     return Object.entries(res.results).reduce(
-    (orderedResult, [, contractResult]) => {
+      (orderedResult, [, contractResult]) => {
         return contractResult.callsReturnContext.reduce((obj, cur) => {
           const order = Number(cur.reference);
           const value = this.decodeReturnValues(cur);
@@ -125,23 +128,25 @@ export class Web3MulticallAdapter extends MulticallBaseAdapter {
     );
   }
 
-  private getChunks(callContexts: ContractCallContext[]) : ContractCallContext[][] {
-    if (this.multiCallParams?.mode === 'chunks') {
-      let chunks : ContractCallContext[][] = [];
-      const CHUNK_SIZE = (this.multiCallParams?.chunkSize || 10);
+  private getChunks(
+    callContexts: ContractCallContext[]
+  ): ContractCallContext[][] {
+    if (this.multiCallParams?.mode === "chunks") {
+      let chunks: ContractCallContext[][] = [];
+      const CHUNK_SIZE = this.multiCallParams?.chunkSize || 10;
       while (callContexts.length > 0) {
-        chunks = chunks.concat([callContexts.splice(0, CHUNK_SIZE)])
+        chunks = chunks.concat([callContexts.splice(0, CHUNK_SIZE)]);
       }
       return chunks;
     }
     return [callContexts];
   }
 
-  private _mergeArray(result : any[], chunkResult : any[]) {
+  private _mergeArray(result: any[], chunkResult: any[]) {
     for (let i = 0; i < chunkResult.length; i++) {
       if (chunkResult[i] !== undefined) {
         if (result[i] !== undefined) {
-          throw new Error('Two values for the same index')
+          throw new Error("Two values for the same index");
         }
         result[i] = chunkResult[i];
       }

--- a/packages/core-sdk/lib/Adapters/Multicall/Web3MulticallAdapter.ts
+++ b/packages/core-sdk/lib/Adapters/Multicall/Web3MulticallAdapter.ts
@@ -16,11 +16,14 @@ type GroupedUseCases = {
   contractAddress: string;
   useCases: Array<{ order: number; useCase: GenericUseCase }>;
 };
+
+type MultiCallParams = { mode?: 'chunks' | 'single', chunkSize?: number }
+
 type OrderedContractUseCaseMap = Record<string, GroupedUseCases>;
 
 export class Web3MulticallAdapter extends MulticallBaseAdapter {
   protected multicall?: Multicall;
-  constructor(adapter: IAdapter) {
+  constructor(adapter: IAdapter, private multiCallParams: MultiCallParams = {mode: 'chunks', chunkSize: 50}) {
     super(adapter);
 
     if (this.isMulticallSupported) {
@@ -35,7 +38,7 @@ export class Web3MulticallAdapter extends MulticallBaseAdapter {
     }
   }
 
-  execute(useCases: GenericUseCase[]): Promise<ExecutionResponse[]> {
+  async execute(useCases: GenericUseCase[]): Promise<ExecutionResponse[]> {
     if (!this.isMulticallSupported) {
       return super.execute(useCases);
     }
@@ -43,9 +46,15 @@ export class Web3MulticallAdapter extends MulticallBaseAdapter {
       useCases.reduce(this.groupUseCasesByContractKeepingOrder.bind(this), {})
     ).map(this.mapGroupedUseCasesToMulticallCtx.bind(this));
 
-    return this.multicall
-      .call(callContexts)
-      .then(this.processMulticallResult.bind(this));
+    const chunks = this.getChunks([...callContexts]);
+    let result : ExecutionResponse<any>[] = []
+    for (let chunk of chunks) {
+      let chunkResult = await this.multicall
+      .call(chunk)
+      .then<ExecutionResponse<any>[]>(this.processMulticallResult.bind(this));
+      this._mergeArray(result, chunkResult);
+    }
+    return result;
   }
 
   private mapGroupedUseCasesToMulticallCtx(
@@ -94,7 +103,7 @@ export class Web3MulticallAdapter extends MulticallBaseAdapter {
     res: ContractCallResults
   ): ExecutionResponse[] {
     return Object.entries(res.results).reduce(
-      (orderedResult, [, contractResult]) => {
+    (orderedResult, [, contractResult]) => {
         return contractResult.callsReturnContext.reduce((obj, cur) => {
           const order = Number(cur.reference);
           const value = this.decodeReturnValues(cur);
@@ -114,5 +123,28 @@ export class Web3MulticallAdapter extends MulticallBaseAdapter {
       },
       []
     );
+  }
+
+  private getChunks(callContexts: ContractCallContext[]) : ContractCallContext[][] {
+    if (this.multiCallParams?.mode === 'chunks') {
+      let chunks : ContractCallContext[][] = [];
+      const CHUNK_SIZE = (this.multiCallParams?.chunkSize || 10);
+      while (callContexts.length > 0) {
+        chunks = chunks.concat([callContexts.splice(0, CHUNK_SIZE)])
+      }
+      return chunks;
+    }
+    return [callContexts];
+  }
+
+  private _mergeArray(result : any[], chunkResult : any[]) {
+    for (let i = 0; i < chunkResult.length; i++) {
+      if (chunkResult[i] !== undefined) {
+        if (result[i] !== undefined) {
+          throw new Error('Two values for the same index')
+        }
+        result[i] = chunkResult[i];
+      }
+    }
   }
 }


### PR DESCRIPTION

# 'can i haz gif plz, kthxbye'

![example](https://media.giphy.com/media/6FNdtLVuuciWI/giphy.gif)

## Description

Implement batches in Web3MulticallAdapter

[Asana Ticket](https://app.asana.com/0/1201291438153499/1201515776246904)

Web3MulticallAdapter has been changed in order enable to execute the multicall requests in chunks of a specified size

## Known Impacted Areas of Code

* Web3MulticallAdapter class.

## Steps taken to Recreate / Verify

* Checkout the PR branch locally
* Execute yarn link
* Use this link in uTrade
* You may get an error in @unifiprotocol/utils package, if this is the case you've only got to link to the folder's package with yarn

## Checklists

### Pull Request Author
I have verified...
- [x] It works in uTrade with different networks
  
