### PR TITLE
feat: calculate tx fee on web3 compatible

### DIFF
--- a/packages/core-sdk/lib/Blockchains/Harmony/Adapters/HarmonyAdapter.ts
+++ b/packages/core-sdk/lib/Blockchains/Harmony/Adapters/HarmonyAdapter.ts
@@ -292,6 +292,7 @@ function mapHmyTxToGlobal(block: IBlock, hmyTx: any): ITransactionReceipt {
   return {
     hash: hmyTx.hash,
     value: hexToNumber(hmyTx.value),
+    txFee: null,
     blockNumber: block.number,
     blockHash: block.hash,
     timestamp: block.timestamp,

--- a/packages/core-sdk/lib/Blockchains/Tron/Utils/Normalizers.ts
+++ b/packages/core-sdk/lib/Blockchains/Tron/Utils/Normalizers.ts
@@ -46,6 +46,7 @@ export function mapTronTxToGlobal(
   return {
     hash: ensureHexPrefix(tronTx.txID), // string
     value: scData?.call_value || "0",
+    txFee: null,
     status:
       tronTx.ret[0].contractRet === "SUCCESS"
         ? TransactionStatus.Success

--- a/packages/core-sdk/lib/Types/BlockAndTxs.ts
+++ b/packages/core-sdk/lib/Types/BlockAndTxs.ts
@@ -24,6 +24,7 @@ type ScArgs = Record<string, any>;
 export interface ITransactionReceipt {
   hash: string;
   blockNumber?: number;
+  txFee: string;
   status?: TransactionStatus;
   blockHash?: string;
   timestamp?: number;


### PR DESCRIPTION
Before the bridge we were not capturing transaction made by the company. Now that we have the bridge and the upcoming UPv2 token, we are going to spend gas, therefore it would be nice to have in the database the transaction costs in order to gather metrics of our operating expenses in gas.

- [x] Calculate on Web3Provider
- HarmonyProvider not used on the listener, therefore not needed
- TronWeb I do not find a way to get it, we could do it in future implementation.