### PR TITLE
fix: fix problem not connecting wallet on several consecutive changes

### DIFF
--- a/packages/shell/src/Adapter/EnsureAdapter.tsx
+++ b/packages/shell/src/Adapter/EnsureAdapter.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useAdapter } from "./useAdapter";
 import { getStorageKey } from "../Utils/ChainStorage";
+import { usePrevious } from "../Hooks/usePrevious";
 
 const ConnectingAdapter = styled.div`
   margin: 2rem;
@@ -11,7 +12,8 @@ const ConnectingAdapter = styled.div`
 `;
 
 export const EnsureAdapter: React.FC = ({ children }) => {
-  const { connect, connectOffline, activeChain, isAdapterReady } = useAdapter();
+  const { connect, connectOffline, activeChain, isAdapterReady, connector } =
+    useAdapter();
   useEffect(() => {
     const lastConnector = getStorageKey<Connectors>(
       activeChain.blockchain,
@@ -32,6 +34,14 @@ export const EnsureAdapter: React.FC = ({ children }) => {
     }
     setTimeout(() => setSecondsWaiting(secondsWaiting + 1), 1000);
   }, [secondsWaiting, isAdapterReady]);
+
+  const prevConnector = usePrevious(connector);
+
+  useEffect(() => {
+    if (connector !== prevConnector && prevConnector?.isWallet) {
+      prevConnector?.disconnect();
+    }
+  }, [connector, prevConnector]);
 
   const dots = (secondsWaiting % 3) + 1;
 

--- a/packages/shell/src/Adapter/useAdapter.ts
+++ b/packages/shell/src/Adapter/useAdapter.ts
@@ -111,7 +111,6 @@ export const useAdapter = () => {
   const updateChain = useCallback(
     (cfg: IConfig) => {
       setChainOnStorage(cfg.blockchain);
-      connector?.disconnect();
       connectOffline();
       dispatch({
         type: AdapterActionKind.SWITCH_CHAIN,

--- a/packages/shell/src/Balances/BalancesUpdater.tsx
+++ b/packages/shell/src/Balances/BalancesUpdater.tsx
@@ -12,6 +12,7 @@ import {
 } from "../EventBus/Events/BalancesEvents";
 import { coinGeckoService } from "../Services/Coingecko";
 import { AddressChangedEvent } from "../EventBus/Events/AdapterEvents";
+import { usePrevious } from "../Hooks/usePrevious";
 
 export const BalancesUpdater = () => {
   const [initialTrigger, setInitialTrigger] = useState(false);
@@ -19,6 +20,7 @@ export const BalancesUpdater = () => {
   const { refreshingBalances, addToken, refresh, wipe, updateUnfiPrice } =
     useBalances();
   const { adapter } = useAdapter();
+  const prevAdapter = usePrevious(adapter);
 
   useEffect(() => {
     Clocks.on("SIXTY_SECONDS", refresh);
@@ -28,8 +30,11 @@ export const BalancesUpdater = () => {
   }, [refresh]);
 
   useEffect(() => {
-    refresh();
-  }, [adapter]);
+    if (adapter !== prevAdapter) {
+      wipe();
+      refresh();
+    }
+  }, [prevAdapter, adapter, refresh]);
 
   useEffect(() => {
     const fn = () =>

--- a/packages/shell/src/Hooks/usePrevious.ts
+++ b/packages/shell/src/Hooks/usePrevious.ts
@@ -1,0 +1,11 @@
+import { useRef, useEffect } from "react";
+
+export const usePrevious = <T>(value: T) => {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+};


### PR DESCRIPTION
Fixed bug that leaded into wallets not connecting correctly after several consecutive network changes

## Description

The problem was that Connectors weren't correctly disconnecting. Now when connector changes the previous gets disconnected as long as it is a wallet.

## Checklists

I have verified in uTrade, uBridge, Shell sample app...
- [x] WalletConnect works fine
- [x] Network changes correctly

