### PR TITLE
feat: add ws support

### DIFF
--- a/packages/core-sdk/lib/Adapters/Web3BaseAdapter.ts
+++ b/packages/core-sdk/lib/Adapters/Web3BaseAdapter.ts
@@ -17,10 +17,6 @@ import {
   SignMessageParams,
 } from "../Types";
 
-type AgnosticWeb3Provider =
-  | ethers.providers.Web3Provider
-  | ethers.providers.WebSocketProvider;
-
 import { nonSuccessResponse, successResponse } from "./Helpers";
 import { ERC20ABI } from "../Abis";
 import { BaseAdapter } from "./BaseAdapter";
@@ -119,8 +115,8 @@ export class Web3BaseAdapter extends BaseAdapter<
     );
   }
 
-  protected get web3Provider(): AgnosticWeb3Provider {
-    return this.etherClient as AgnosticWeb3Provider;
+  protected get web3Provider(): ethers.providers.Web3Provider {
+    return this.etherClient as ethers.providers.Web3Provider;
   }
 
   async initializeToken(

--- a/packages/core-sdk/lib/Adapters/Web3BaseAdapter.ts
+++ b/packages/core-sdk/lib/Adapters/Web3BaseAdapter.ts
@@ -17,6 +17,10 @@ import {
   SignMessageParams,
 } from "../Types";
 
+type AgnosticWeb3Provider =
+  | ethers.providers.Web3Provider
+  | ethers.providers.WebSocketProvider;
+
 import { nonSuccessResponse, successResponse } from "./Helpers";
 import { ERC20ABI } from "../Abis";
 import { BaseAdapter } from "./BaseAdapter";
@@ -115,8 +119,8 @@ export class Web3BaseAdapter extends BaseAdapter<
     );
   }
 
-  protected get web3Provider(): ethers.providers.Web3Provider {
-    return this.etherClient as ethers.providers.Web3Provider;
+  protected get web3Provider(): AgnosticWeb3Provider {
+    return this.etherClient as AgnosticWeb3Provider;
   }
 
   async initializeToken(

--- a/packages/core-sdk/lib/Connectors/Offline/Web3BaseConnector.ts
+++ b/packages/core-sdk/lib/Connectors/Offline/Web3BaseConnector.ts
@@ -33,12 +33,12 @@ export class Web3BaseConnector extends BaseConnector {
   private buildWeb3Provider() {
     const protocol = new URL(this.nodeUrl).protocol;
 
-    if (/^http/.test(protocol)) {
+    if (/^http/i.test(protocol)) {
       return new ethers.providers.StaticJsonRpcProvider(
         this.nodeUrl,
         this.config.chainId
       );
-    } else if (/^ws/.test(protocol)) {
+    } else if (/^ws/i.test(protocol)) {
       return new ethers.providers.WebSocketProvider(
         this.nodeUrl,
         this.config.chainId

--- a/packages/core-sdk/lib/Types/Enums.ts
+++ b/packages/core-sdk/lib/Types/Enums.ts
@@ -37,6 +37,7 @@ export enum OfflineConnectors {
   BTTC = "bttc",
   OntologyTestnet = "ontologytestnet",
   FTM = "ftm",
+  Goerli = "Goerli",
 }
 
 export enum WalletConnectors {


### PR DESCRIPTION
Web3BaseAdapter makes use of an underneath web3-compatible provider through which the requests are being sent. Formerly, we used `ethers.providers.StaticJsonRpcProvider` as the adapter's provider. 

It's not a big change since the interfaces of both are equal and the operations are the same with the sole difference of the communication protocol.

I tested for Web3BaseConnector using a ws node:
- [x] Connection is established correctly
- [x] It gets information about blocks, transactions...
- [x] It executes reading operations correctly (Write ops. were not considered since these connectors are RO)